### PR TITLE
Feature - added styleObjectModelName validation

### DIFF
--- a/__tests__/config-validator/base-properties.js
+++ b/__tests__/config-validator/base-properties.js
@@ -48,6 +48,15 @@ test('uploadDir is mutual exclusive with assets', () => {
 });
 
 describe('styleObjectModelName', () => {
+    test('should pass validation when styleObjectModelName is set and refers to a valid model', () => {
+        expectPassingValidation({
+            styleObjectModelName: 'model_1',
+            models: {
+                model_1: { type: 'data', label: 'model_1' },
+            }
+        });
+    });
+
     test('styleObjectModelName must reference an existing model', () => {
         expectValidationResultToIncludeSingleError(
             {

--- a/__tests__/config-validator/base-properties.js
+++ b/__tests__/config-validator/base-properties.js
@@ -47,20 +47,38 @@ test('uploadDir is mutual exclusive with assets', () => {
     );
 });
 
-test('styleObjectModelName must reference an existing model', () => {
-    expectValidationResultToIncludeSingleError(
-        {
-            styleObjectModelName: 'invalid',
-            models: {
-                model_1: { type: 'page', label: 'model_1' }
+describe('styleObjectModelName', () => {
+    test('styleObjectModelName must reference an existing model', () => {
+        expectValidationResultToIncludeSingleError(
+            {
+                styleObjectModelName: 'invalid',
+                models: {
+                    model_1: { type: 'page', label: 'model_1' },
+                }
+            },
+            {
+                type: 'styleObjectModelName.model.missing',
+                fieldPath: ['styleObjectModelName'],
+                message: expect.stringContaining('styleObjectModelName must reference an existing model')
             }
-        },
-        {
-            type: 'styleObjectModelName.model.missing',
-            fieldPath: ['styleObjectModelName'],
-            message: expect.stringContaining('"styleObjectModelName" must reference an existing model')
-        }
-    );
+        );
+    });
+
+    test('styleObjectModelName must reference a model of type "object"', () => {
+        expectValidationResultToIncludeSingleError(
+            {
+                styleObjectModelName: 'model_1',
+                models: {
+                    model_1: { type: 'page', label: 'model_1' }
+                }
+            },
+            {
+                type: 'styleObjectModelName.model.type',
+                fieldPath: ['styleObjectModelName'],
+                message: expect.stringContaining('Model defined in styleObjectModelName ("model_1") must be of type "object"')
+            }
+        );
+    });
 });
 
 describe('static assets', () => {

--- a/__tests__/config-validator/base-properties.js
+++ b/__tests__/config-validator/base-properties.js
@@ -68,7 +68,7 @@ describe('styleObjectModelName', () => {
             {
                 type: 'styleObjectModelName.model.missing',
                 fieldPath: ['styleObjectModelName'],
-                message: expect.stringContaining('styleObjectModelName must reference an existing model')
+                message: expect.stringMatching('styleObjectModelName must reference an existing model')
             }
         );
     });
@@ -84,7 +84,7 @@ describe('styleObjectModelName', () => {
             {
                 type: 'styleObjectModelName.model.type',
                 fieldPath: ['styleObjectModelName'],
-                message: expect.stringContaining('Model defined in styleObjectModelName ("model_1") must be of type "object"')
+                message: expect.stringMatching('Model defined in styleObjectModelName must be of type data - model_1')
             }
         );
     });

--- a/__tests__/config-validator/base-properties.js
+++ b/__tests__/config-validator/base-properties.js
@@ -47,6 +47,22 @@ test('uploadDir is mutual exclusive with assets', () => {
     );
 });
 
+test('styleObjectModelName must reference an existing model', () => {
+    expectValidationResultToIncludeSingleError(
+        {
+            styleObjectModelName: 'invalid',
+            models: {
+                model_1: { type: 'page', label: 'model_1' }
+            }
+        },
+        {
+            type: 'styleObjectModelName.model.missing',
+            fieldPath: ['styleObjectModelName'],
+            message: expect.stringContaining('"styleObjectModelName" must reference an existing model')
+        }
+    );
+});
+
 describe('static assets', () => {
     test('should pass validation when "referenceType" is "static", and the "staticDir" and the "publicPath" properties are specified', () => {
         expectPassingValidation({

--- a/src/config/config-schema.ts
+++ b/src/config/config-schema.ts
@@ -195,20 +195,25 @@ const variantFieldSchema = Joi.custom((value, { error, state }) => {
 });
 
 const styleObjectModelReferenceError = 'styleObjectModelName.model.missing';
+const styleObjectModelNotObject = 'styleObjectModelName.model.type';
 const styleObjectModelNameSchema = Joi.string()
     .allow('', null)
     .custom((value, { error, state }) => {
         const models = getModelsFromValidationState(state);
         const modelNames = Object.keys(models);
         const objectModelNames = modelNames.filter((modelName) => models[modelName]!.type === 'object');
-        if (!objectModelNames.includes(value)) {
+        if (!modelNames.includes(value)) {
             return error(styleObjectModelReferenceError);
+        }
+        if (models[value]!.type !== 'object') {
+            return error(styleObjectModelNotObject);
         }
         return value;
     })
     .prefs({
         messages: {
-            [styleObjectModelReferenceError]: '"{{#label}}" must reference an existing model'
+            [styleObjectModelReferenceError]: '{{#label}} must reference an existing model',
+            [styleObjectModelNotObject]: 'Model defined in {{#label}} ("{{#value}}") must be of type "object"'
         },
         errors: { wrap: { label: false } }
     });

--- a/src/config/config-schema.ts
+++ b/src/config/config-schema.ts
@@ -201,11 +201,10 @@ const styleObjectModelNameSchema = Joi.string()
     .custom((value, { error, state }) => {
         const models = getModelsFromValidationState(state);
         const modelNames = Object.keys(models);
-        const objectModelNames = modelNames.filter((modelName) => models[modelName]!.type === 'object');
         if (!modelNames.includes(value)) {
             return error(styleObjectModelReferenceError);
         }
-        if (models[value]!.type !== 'object') {
+        if (models[value]!.type !== 'data') {
             return error(styleObjectModelNotObject);
         }
         return value;

--- a/src/config/config-schema.ts
+++ b/src/config/config-schema.ts
@@ -194,6 +194,25 @@ const variantFieldSchema = Joi.custom((value, { error, state }) => {
     errors: { wrap: { label: false } }
 });
 
+const styleObjectModelReferenceError = 'styleObjectModelName.model.missing';
+const styleObjectModelNameSchema = Joi.string()
+    .allow('', null)
+    .custom((value, { error, state }) => {
+        const models = getModelsFromValidationState(state);
+        const modelNames = Object.keys(models);
+        const objectModelNames = modelNames.filter((modelName) => models[modelName]!.type === 'object');
+        if (!objectModelNames.includes(value)) {
+            return error(styleObjectModelReferenceError);
+        }
+        return value;
+    })
+    .prefs({
+        messages: {
+            [styleObjectModelReferenceError]: '"{{#label}}" must reference an existing model'
+        },
+        errors: { wrap: { label: false } }
+    });
+
 const contentfulImportSchema = Joi.object<ContentfulImport>({
     type: Joi.string().valid('contentful').required(),
     contentFile: Joi.string().required(),
@@ -645,6 +664,7 @@ export const stackbitConfigSchema = Joi.object<YamlConfig>({
     dataDir: Joi.string().allow('', null),
     pageLayoutKey: Joi.string().allow(null),
     objectTypeKey: Joi.string(),
+    styleObjectModelName: styleObjectModelNameSchema,
     excludePages: Joi.array().items(Joi.string()).single(),
     logicFields: Joi.array().items(logicField),
     contentModels: Joi.any(),

--- a/src/config/config-schema.ts
+++ b/src/config/config-schema.ts
@@ -212,7 +212,7 @@ const styleObjectModelNameSchema = Joi.string()
     .prefs({
         messages: {
             [styleObjectModelReferenceError]: '{{#label}} must reference an existing model',
-            [styleObjectModelNotObject]: 'Model defined in {{#label}} ("{{#value}}") must be of type "object"'
+            [styleObjectModelNotObject]: 'Model defined in {{#label}} must be of type data - {{#value}}'
         },
         errors: { wrap: { label: false } }
     });

--- a/src/config/config-types.ts
+++ b/src/config/config-types.ts
@@ -27,6 +27,7 @@ interface BaseConfig {
     dataDir?: string | null;
     pageLayoutKey?: string | null;
     objectTypeKey?: string;
+    styleObjectModelName?: string | null;
     excludePages?: string | string[];
     logicFields?: LogicField[];
     contentModels?: ContentModelMap;


### PR DESCRIPTION
https://www.notion.so/stackbit/Global-styles-Schema-and-propagation-94b87b3824ad422c9dc3c160ea3b5172

styleObjectModelName is a new sb.yaml key which refers to which model is in charge of the global styling of the theme.